### PR TITLE
Set option flag to adjust library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,12 @@ set(PMC_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/pmc_clique_utils.cpp
         )
 
-add_library(pmc SHARED ${PMC_SOURCE_FILES})
+option(PMC_BUILD_SHARED "Build pmc as a shared library (.so)" ON)
+if (PMC_BUILD_SHARED)
+        add_library(pmc SHARED ${PMC_SOURCE_FILES})
+else()
+        add_library(pmc STATIC ${PMC_SOURCE_FILES})
+endif()
 
 target_include_directories(pmc PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>


### PR DESCRIPTION
## Why does it matter?

Now I'm setting up the Pypi pipeline using GitHub Action in the ROBIN repository, and I've confronted the below error:

![image](https://github.com/user-attachments/assets/2683b77a-7852-430c-b3b2-118ed592b371)

I suspect this error is because of the type of `libpmc.so`; if it was `libpmc.a`, then we can resolve the error.

(The total error can be found here: https://github.com/MIT-SPARK/ROBIN/actions/runs/13013940332/job/36298262113)

---
## Solution.

So, I want to set an option to control the output library type. Note that in default mode, it won't change any pipeline (i.e., it doesn't break other libraries such as TEASER or something)

## How to use

![image](https://github.com/user-attachments/assets/7317cadd-3f9e-4dff-975e-4a5d27ca7afc)

We can adjust the type; whether `libpmc.a` or `libpmc.so`.