### PR TITLE
Conform the library to better coding standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
         add_library(pmc STATIC ${PMC_SOURCE_FILES})
 endif()
 
-target_compile_options(pmc PUBLIC
+target_compile_options(pmc PRIVATE
         -Wall
         -Werror
         -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,15 @@ else()
         add_library(pmc STATIC ${PMC_SOURCE_FILES})
 endif()
 
+target_compile_options(pmc PUBLIC
+        -Wall
+        -Werror
+        -Wextra
+        -Wno-format
+        -Wno-sign-compare
+        -Wno-unused-function
+)
+
 target_include_directories(pmc PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/include/pmc/pmc_bool_vector.h
+++ b/include/pmc/pmc_bool_vector.h
@@ -1,0 +1,46 @@
+#ifndef PMC_BOOL_VECTOR_H_
+#define PMC_BOOL_VECTOR_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace pmc {
+class bool_vector {
+public:
+  bool_vector(std::size_t size = 0UL, bool value = false)
+      : data_(size, to_int(value)) {}
+
+  void resize(std::size_t size, bool value = false) {
+    data_.resize(size, to_int(value));
+  }
+
+  class Reference {
+  public:
+    Reference(std::uint8_t &byte) : byte_(byte) {}
+
+    operator bool() const noexcept { return byte_ != 0; }
+
+    Reference &operator=(bool value) noexcept {
+      byte_ = to_int(value);
+      return *this;
+    }
+
+  private:
+    std::uint8_t &byte_;
+  };
+
+  bool operator[](std::size_t i) const noexcept { return data_[i] != 0; }
+
+  Reference operator[](std::size_t i) noexcept { return Reference(data_[i]); }
+
+private:
+  static constexpr std::uint8_t to_int(bool value) noexcept {
+    return value ? 1 : 0;
+  }
+
+  std::vector<std::uint8_t> data_;
+};
+} // namespace pmc
+
+#endif

--- a/include/pmc/pmc_bool_vector.h
+++ b/include/pmc/pmc_bool_vector.h
@@ -1,55 +1,38 @@
 #ifndef PMC_BOOL_VECTOR_H_
 #define PMC_BOOL_VECTOR_H_
 
-#include <cstddef>
 #include <cstdint>
 #include <vector>
 
 namespace pmc {
+
 /// A bare minimum implementation of a boolean vector.
 ///
 /// This class is recommended in place of std::vector<bool> or std::vector<int> for thread-safety.
 /// std::vector<bool> could cause a race condition if it is implemented as a dynamic bitset.
 /// std::vector<int> is not memory efficient and misleading as an element can hold other than 0 or 1.
-class bool_vector {
-public:
-  bool_vector(std::size_t size = 0UL, bool value = false)
-      : data_(size, to_int(value)) {}
+class bool_wrapper {
+ public:
+  /// NOTE: It should not be marked `explicit` to allow implicit conversion from `bool` to `bool_wrapper`.
+  bool_wrapper(bool value = false) : byte_(to_int(value)) {}
 
-  std::size_t size() const noexcept { return data_.size(); }
+  operator bool() const noexcept { return byte_ != 0; }
 
-  bool empty() const noexcept { return data_.empty(); }
-
-  void resize(std::size_t size, bool value = false) {
-    data_.resize(size, to_int(value));
+  bool_wrapper& operator=(bool value) noexcept {
+    byte_ = to_int(value);
+    return *this;
   }
 
-  class Reference {
-  public:
-    Reference(std::uint8_t &byte) : byte_(byte) {}
-
-    operator bool() const noexcept { return byte_ != 0; }
-
-    Reference &operator=(bool value) noexcept {
-      byte_ = to_int(value);
-      return *this;
-    }
-
-  private:
-    std::uint8_t &byte_;
-  };
-
-  bool operator[](std::size_t i) const noexcept { return data_[i] != 0; }
-
-  Reference operator[](std::size_t i) noexcept { return Reference(data_[i]); }
-
-private:
+ private:
   static constexpr std::uint8_t to_int(bool value) noexcept {
     return value ? 1 : 0;
   }
 
-  std::vector<std::uint8_t> data_;
+  std::uint8_t byte_;
 };
+
+using bool_vector = std::vector<bool_wrapper>;
+
 } // namespace pmc
 
 #endif

--- a/include/pmc/pmc_bool_vector.h
+++ b/include/pmc/pmc_bool_vector.h
@@ -16,6 +16,10 @@ public:
   bool_vector(std::size_t size = 0UL, bool value = false)
       : data_(size, to_int(value)) {}
 
+  std::size_t size() const noexcept { return data_.size(); }
+
+  bool empty() const noexcept { return data_.empty(); }
+
   void resize(std::size_t size, bool value = false) {
     data_.resize(size, to_int(value));
   }

--- a/include/pmc/pmc_bool_vector.h
+++ b/include/pmc/pmc_bool_vector.h
@@ -6,6 +6,11 @@
 #include <vector>
 
 namespace pmc {
+/// A bare minimum implementation of a boolean vector.
+///
+/// This class is recommended in place of std::vector<bool> or std::vector<int> for thread-safety.
+/// std::vector<bool> could cause a race condition if it is implemented as a dynamic bitset.
+/// std::vector<int> is not memory efficient and misleading as an element can hold other than 0 or 1.
 class bool_vector {
 public:
   bool_vector(std::size_t size = 0UL, bool value = false)

--- a/include/pmc/pmc_debug_utils.h
+++ b/include/pmc/pmc_debug_utils.h
@@ -5,10 +5,13 @@
 #ifndef PMC_DEBUG_UTILS_H_
 #define PMC_DEBUG_UTILS_H_
 
+template <class... Args>
+constexpr void discard(Args&&... /*args*/) {}
+
 #ifdef PMC_ENABLE_DEBUG
 #define DEBUG_PRINTF(...) printf(__VA_ARGS__)
 #else
-#define DEBUG_PRINTF(...) do {} while (0)
+#define DEBUG_PRINTF(...) discard(__VA_ARGS__)
 #endif
 
 #endif //PMC_DEBUG_UTILS_H_

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -69,8 +69,8 @@ namespace pmc {
                     std::vector<int>& es,
                     const bool_vector& pruned);
 
-            int num_vertices() { return vertices.size() - 1; }
-            int num_edges() { return edges.size()/2; }
+            int num_vertices() const noexcept { return vertices.size() - 1; }
+            int num_edges() const noexcept { return edges.size()/2; }
             const std::vector <long long>& get_vertices() const noexcept { return vertices; }
             const std::vector<int>& get_edges() const noexcept { return edges; }
             std::vector<int>* get_degree(){ return &degree; }
@@ -78,19 +78,19 @@ namespace pmc {
             std::vector<long long> get_vertices_array() { return vertices; };
             std::vector<long long> e_v, e_u, eid;
 
-            int vertex_degree(int v) { return vertices[v] - vertices[v+1]; }
-            long long first_neigh(int v) { return vertices[v]; }
-            long long last_neigh(int v) { return vertices[v+1]; }
+            int vertex_degree(int v) const noexcept { return vertices[v] - vertices[v+1]; }
+            long long first_neigh(int v) const noexcept { return vertices[v]; }
+            long long last_neigh(int v) const noexcept { return vertices[v+1]; }
 
             void sum_vertex_degrees();
             void vertex_degrees();
             void update_degrees();
             void update_degrees(bool flag);
             void update_degrees(bool_vector& pruned, int& mc);
-            double density() { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
-            int get_max_degree() { return max_degree; }
-            int get_min_degree() { return min_degree; }
-            double get_avg_degree() { return avg_degree; }
+            double density() const noexcept { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
+            int get_max_degree() const noexcept { return max_degree; }
+            int get_min_degree() const noexcept { return min_degree; }
+            double get_avg_degree() const noexcept { return avg_degree; }
 
             void initialize();
             std::string get_file_extension(const std::string& filename);
@@ -109,7 +109,7 @@ namespace pmc {
             std::vector<int> kcore_order;
             std::vector<int>* get_kcores() { return &kcore; }
             std::vector<int>* get_kcore_ordering() { return &kcore_order; }
-            int get_max_core() { return max_core; }
+            int get_max_core() const noexcept { return max_core; }
             void update_kcores(const bool_vector& pruned);
 
             void compute_cores();

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -33,7 +33,7 @@ namespace pmc {
             // helper functions
             void read_mtx(const std::string& filename);
             void read_edges(const std::string& filename);
-            void read_metis(const std::string& filename);
+            void read_metis(const std::string& /*filename*/) {}
 
         public:
             std::vector<int> edges;
@@ -67,9 +67,7 @@ namespace pmc {
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    const bool_vector& pruned,
-                    int id,
-                    int& mc);
+                    const bool_vector& pruned);
 
             int num_vertices() { return vertices.size() - 1; }
             int num_edges() { return edges.size()/2; }
@@ -97,7 +95,7 @@ namespace pmc {
             void initialize();
             std::string get_file_extension(const std::string& filename);
             void basic_stats(double sec);
-            void bound_stats(int alg, int lb, pmc_graph& G);
+            void bound_stats(int alg);
 
             // vertex sorter
             void compute_ordering(std::vector<int>& bound, std::vector<int>& order);
@@ -135,9 +133,7 @@ namespace pmc {
                     std::vector<long long>& vs,
                     std::vector<int>& es,
                     const bool_vector& pruned,
-                    pmc_graph& G,
-                    int id,
-                    int& mc);
+                    pmc_graph& G);
 
             bool clique_test(pmc_graph& G, std::vector<int> C);
     };

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -64,11 +64,11 @@ namespace pmc {
 
             void read_graph(const std::string& filename);
             void create_adj();
-            void reduce_graph(std::vector<int>& pruned);
+            void reduce_graph(const std::vector<std::uint8_t>& pruned);
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    std::vector<int>& pruned,
+                    const std::vector<std::uint8_t>& pruned,
                     int id,
                     int& mc);
 
@@ -89,7 +89,7 @@ namespace pmc {
             void vertex_degrees();
             void update_degrees();
             void update_degrees(bool flag);
-            void update_degrees(std::vector<int>& pruned, int& mc);
+            void update_degrees(std::vector<std::uint8_t>& pruned, int& mc);
             double density() { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
             int get_max_degree() { return max_degree; }
             int get_min_degree() { return min_degree; }
@@ -113,17 +113,16 @@ namespace pmc {
             std::vector<int>* get_kcores() { return &kcore; }
             std::vector<int>* get_kcore_ordering() { return &kcore_order; }
             int get_max_core() { return max_core; }
-            void update_kcores(std::vector<int>& pruned);
+            void update_kcores(const std::vector<std::uint8_t>& pruned);
 
             void compute_cores();
             void induced_cores_ordering(
                     std::vector<long long>& V,
-                    std::vector<int>& E,
-                    std::vector<int>& pruned);
+                    std::vector<int>& E);
 
             // clique utils
-            int initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb);
-            int initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
+            int initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb);
+            int initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
             void order_vertices(std::vector<Vertex> &V, pmc_graph &G,
                     int &lb_idx, int &lb, std::string vertex_ordering, bool decr_order);
 
@@ -136,7 +135,7 @@ namespace pmc {
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    std::vector<int>& pruned,
+                    const std::vector<std::uint8_t>& pruned,
                     pmc_graph& G,
                     int id,
                     int& mc);

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -20,10 +20,9 @@
 #ifndef PMC_GRAPH_H_
 #define PMC_GRAPH_H_
 
-#include "math.h"
+#include "pmc/pmc_bool_vector.h"
 #include "pmc_vertex.h"
 
-#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -45,7 +44,7 @@ namespace pmc {
             double avg_degree;
             bool is_gstats;
             std::string fn;
-            std::vector<std::vector<std::uint8_t>> adj;
+            std::vector<bool_vector> adj;
 
             // constructor
             pmc_graph(const std::string& filename);
@@ -64,11 +63,11 @@ namespace pmc {
 
             void read_graph(const std::string& filename);
             void create_adj();
-            void reduce_graph(const std::vector<std::uint8_t>& pruned);
+            void reduce_graph(const bool_vector& pruned);
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    const std::vector<std::uint8_t>& pruned,
+                    const bool_vector& pruned,
                     int id,
                     int& mc);
 
@@ -89,7 +88,7 @@ namespace pmc {
             void vertex_degrees();
             void update_degrees();
             void update_degrees(bool flag);
-            void update_degrees(std::vector<std::uint8_t>& pruned, int& mc);
+            void update_degrees(bool_vector& pruned, int& mc);
             double density() { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
             int get_max_degree() { return max_degree; }
             int get_min_degree() { return min_degree; }
@@ -113,7 +112,7 @@ namespace pmc {
             std::vector<int>* get_kcores() { return &kcore; }
             std::vector<int>* get_kcore_ordering() { return &kcore_order; }
             int get_max_core() { return max_core; }
-            void update_kcores(const std::vector<std::uint8_t>& pruned);
+            void update_kcores(const bool_vector& pruned);
 
             void compute_cores();
             void induced_cores_ordering(
@@ -121,8 +120,8 @@ namespace pmc {
                     std::vector<int>& E);
 
             // clique utils
-            int initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb);
-            int initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
+            int initial_pruning(pmc_graph& G, bool_vector& pruned, int lb);
+            int initial_pruning(pmc_graph& G, bool_vector& pruned, int lb, std::vector<bool_vector>& adj);
             void order_vertices(std::vector<Vertex> &V, pmc_graph &G,
                     int &lb_idx, int &lb, std::string vertex_ordering, bool decr_order);
 
@@ -135,7 +134,7 @@ namespace pmc {
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    const std::vector<std::uint8_t>& pruned,
+                    const bool_vector& pruned,
                     pmc_graph& G,
                     int id,
                     int& mc);

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -64,11 +64,11 @@ namespace pmc {
 
             void read_graph(const std::string& filename);
             void create_adj();
-            void reduce_graph(int* &pruned);
+            void reduce_graph(std::vector<int>& pruned);
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int id,
                     int& mc);
 
@@ -89,7 +89,7 @@ namespace pmc {
             void vertex_degrees();
             void update_degrees();
             void update_degrees(bool flag);
-            void update_degrees(int* &pruned, int& mc);
+            void update_degrees(std::vector<int>& pruned, int& mc);
             double density() { return (double)num_edges() / (num_vertices() * (num_vertices() - 1.0) / 2.0); }
             int get_max_degree() { return max_degree; }
             int get_min_degree() { return min_degree; }
@@ -113,17 +113,17 @@ namespace pmc {
             std::vector<int>* get_kcores() { return &kcore; }
             std::vector<int>* get_kcore_ordering() { return &kcore_order; }
             int get_max_core() { return max_core; }
-            void update_kcores(int* &pruned);
+            void update_kcores(std::vector<int>& pruned);
 
             void compute_cores();
             void induced_cores_ordering(
                     std::vector<long long>& V,
                     std::vector<int>& E,
-                    int* &pruned);
+                    std::vector<int>& pruned);
 
             // clique utils
-            int initial_pruning(pmc_graph& G, int* &pruned, int lb);
-            int initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
+            int initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb);
+            int initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
             void order_vertices(std::vector<Vertex> &V, pmc_graph &G,
                     int &lb_idx, int &lb, std::string vertex_ordering, bool decr_order);
 
@@ -136,7 +136,7 @@ namespace pmc {
             void reduce_graph(
                     std::vector<long long>& vs,
                     std::vector<int>& es,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     pmc_graph& G,
                     int id,
                     int& mc);

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -21,11 +21,9 @@
 #define PMC_GRAPH_H_
 
 #include "math.h"
-#include "pmc_headers.h"
-#include "pmc_utils.h"
 #include "pmc_vertex.h"
 
-#include <cstddef>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -58,7 +56,7 @@ namespace pmc {
                 vertex_degrees();
             }
             pmc_graph(long long nedges, const int *ei, const int *ej, int offset);
-            pmc_graph(std::map<int, std::vector<int>> v_map);
+            pmc_graph(const std::map<int, std::vector<int>>& v_map);
 
             // destructor
             ~pmc_graph();

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -71,8 +71,8 @@ namespace pmc {
 
             int num_vertices() { return vertices.size() - 1; }
             int num_edges() { return edges.size()/2; }
-            std::vector <long long>* get_vertices(){ return &vertices; }
-            std::vector<int>* get_edges(){ return &edges; }
+            const std::vector <long long>& get_vertices() const noexcept { return vertices; }
+            const std::vector<int>& get_edges() const noexcept { return edges; }
             std::vector<int>* get_degree(){ return &degree; }
             std::vector<int> get_edges_array() { return edges; }
             std::vector<long long> get_vertices_array() { return vertices; };

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -20,70 +20,67 @@
 #ifndef PMC_GRAPH_H_
 #define PMC_GRAPH_H_
 
-#include <float.h>
-#include <cstddef>
-#include <sys/time.h>
-#include <unistd.h>
-#include <iostream>
-#include <limits>
 #include "math.h"
 #include "pmc_headers.h"
 #include "pmc_utils.h"
 #include "pmc_vertex.h"
 
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace pmc {
     class pmc_graph {
         private:
             // helper functions
-            void read_mtx(const string& filename);
-            void read_edges(const string& filename);
-            void read_metis(const string& filename);
+            void read_mtx(const std::string& filename);
+            void read_edges(const std::string& filename);
+            void read_metis(const std::string& filename);
 
         public:
-            vector<int> edges;
-            vector<long long> vertices;
-            vector<int> degree;
+            std::vector<int> edges;
+            std::vector<long long> vertices;
+            std::vector<int> degree;
             int min_degree;
             int max_degree;
             double avg_degree;
             bool is_gstats;
-            string fn;
-            vector<vector<bool>> adj;
+            std::string fn;
+            std::vector<std::vector<bool>> adj;
 
             // constructor
-            pmc_graph(const string& filename);
-            pmc_graph(bool graph_stats, const string& filename);
-            pmc_graph(const string& filename, bool make_adj);
-            pmc_graph(vector<long long> vs, vector<int> es) {
+            pmc_graph(const std::string& filename);
+            pmc_graph(bool graph_stats, const std::string& filename);
+            pmc_graph(const std::string& filename, bool make_adj);
+            pmc_graph(std::vector<long long> vs, std::vector<int> es) {
                 edges = std::move(es);
                 vertices = std::move(vs);
                 vertex_degrees();
             }
             pmc_graph(long long nedges, const int *ei, const int *ej, int offset);
-            pmc_graph(map<int,vector<int> > v_map);
-                
+            pmc_graph(std::map<int, std::vector<int>> v_map);
+
             // destructor
             ~pmc_graph();
 
-            void read_graph(const string& filename);
+            void read_graph(const std::string& filename);
             void create_adj();
             void reduce_graph(int* &pruned);
             void reduce_graph(
-                    vector<long long>& vs,
-                    vector<int>& es,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
                     int* &pruned,
                     int id,
                     int& mc);
 
             int num_vertices() { return vertices.size() - 1; }
             int num_edges() { return edges.size()/2; }
-            vector <long long>* get_vertices(){ return &vertices; }
-            vector<int>* get_edges(){ return &edges; }
-            vector<int>* get_degree(){ return &degree; }
-            vector<int> get_edges_array() { return edges; }
-            vector<long long> get_vertices_array() { return vertices; };
-            vector<long long> e_v, e_u, eid;
+            std::vector <long long>* get_vertices(){ return &vertices; }
+            std::vector<int>* get_edges(){ return &edges; }
+            std::vector<int>* get_degree(){ return &degree; }
+            std::vector<int> get_edges_array() { return edges; }
+            std::vector<long long> get_vertices_array() { return vertices; };
+            std::vector<long long> e_v, e_u, eid;
 
             int vertex_degree(int v) { return vertices[v] - vertices[v+1]; }
             long long first_neigh(int v) { return vertices[v]; }
@@ -100,52 +97,52 @@ namespace pmc {
             double get_avg_degree() { return avg_degree; }
 
             void initialize();
-            string get_file_extension(const string& filename);
+            std::string get_file_extension(const std::string& filename);
             void basic_stats(double sec);
             void bound_stats(int alg, int lb, pmc_graph& G);
 
             // vertex sorter
-            void compute_ordering(vector<int>& bound, vector<int>& order);
-            void compute_ordering(string degree, vector<int>& order);
+            void compute_ordering(std::vector<int>& bound, std::vector<int>& order);
+            void compute_ordering(std::string degree, std::vector<int>& order);
             // edge sorters
             void degree_bucket_sort();
             void degree_bucket_sort(bool desc);
 
             int max_core;
-            vector<int> kcore;
-            vector<int> kcore_order;
-            vector<int>* get_kcores() { return &kcore; }
-            vector<int>* get_kcore_ordering() { return &kcore_order; }
+            std::vector<int> kcore;
+            std::vector<int> kcore_order;
+            std::vector<int>* get_kcores() { return &kcore; }
+            std::vector<int>* get_kcore_ordering() { return &kcore_order; }
             int get_max_core() { return max_core; }
             void update_kcores(int* &pruned);
 
             void compute_cores();
             void induced_cores_ordering(
-                    vector<long long>& V,
-                    vector<int>& E,
+                    std::vector<long long>& V,
+                    std::vector<int>& E,
                     int* &pruned);
 
             // clique utils
             int initial_pruning(pmc_graph& G, int* &pruned, int lb);
-            int initial_pruning(pmc_graph& G, int* &pruned, int lb, vector<vector<bool>> &adj);
-            void order_vertices(vector<Vertex> &V, pmc_graph &G,
-                    int &lb_idx, int &lb, string vertex_ordering, bool decr_order);
+            int initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<bool>> &adj);
+            void order_vertices(std::vector<Vertex> &V, pmc_graph &G,
+                    int &lb_idx, int &lb, std::string vertex_ordering, bool decr_order);
 
-            void print_info(vector<int> &C_max, double &sec);
+            void print_info(std::vector<int> &C_max, double &sec);
             void print_break();
-            bool time_left(vector<int> &C_max, double sec,
+            bool time_left(std::vector<int> &C_max, double sec,
                     double time_limit, bool &time_expired_msg);
             void graph_stats(pmc_graph& G, int& mc, int id, double &sec);
 
             void reduce_graph(
-                    vector<long long>& vs,
-                    vector<int>& es,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
                     int* &pruned,
                     pmc_graph& G,
                     int id,
                     int& mc);
 
-            bool clique_test(pmc_graph& G, vector<int> C);
+            bool clique_test(pmc_graph& G, std::vector<int> C);
     };
 
 }

--- a/include/pmc/pmc_graph.h
+++ b/include/pmc/pmc_graph.h
@@ -23,6 +23,7 @@
 #include "math.h"
 #include "pmc_vertex.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -44,7 +45,7 @@ namespace pmc {
             double avg_degree;
             bool is_gstats;
             std::string fn;
-            std::vector<std::vector<bool>> adj;
+            std::vector<std::vector<std::uint8_t>> adj;
 
             // constructor
             pmc_graph(const std::string& filename);
@@ -122,7 +123,7 @@ namespace pmc {
 
             // clique utils
             int initial_pruning(pmc_graph& G, int* &pruned, int lb);
-            int initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<bool>> &adj);
+            int initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj);
             void order_vertices(std::vector<Vertex> &V, pmc_graph &G,
                     int &lb_idx, int &lb, std::string vertex_ordering, bool decr_order);
 

--- a/include/pmc/pmc_headers.h
+++ b/include/pmc/pmc_headers.h
@@ -20,18 +20,17 @@
 #ifndef PMC_HEADERS_H_
 #define PMC_HEADERS_H_
 
-#include <iostream>
-#include <stdlib.h>
-#include <vector>
-#include <time.h>
-#include <string.h>
-#include <stdio.h>
-#include <map>
 #include <fstream>
+#include <iostream>
+#include <map>
+#include <omp.h>
 #include <sstream>
 #include <stdint.h>
-#include <omp.h>
-using namespace std;
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <vector>
 
 #ifndef LINE_LENGTH
 #define LINE_LENGTH 256

--- a/include/pmc/pmc_headers.h
+++ b/include/pmc/pmc_headers.h
@@ -20,17 +20,9 @@
 #ifndef PMC_HEADERS_H_
 #define PMC_HEADERS_H_
 
-#include <fstream>
-#include <iostream>
-#include <map>
 #include <omp.h>
-#include <sstream>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <vector>
 
 #ifndef LINE_LENGTH
 #define LINE_LENGTH 256

--- a/include/pmc/pmc_headers.h
+++ b/include/pmc/pmc_headers.h
@@ -20,13 +20,8 @@
 #ifndef PMC_HEADERS_H_
 #define PMC_HEADERS_H_
 
-#include <omp.h>
-#include <stdint.h>
-#include <stdlib.h>
-
 #ifndef LINE_LENGTH
 #define LINE_LENGTH 256
 #endif
-#define NANOSECOND 1000000000
 
 #endif

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -32,8 +32,8 @@ namespace pmc {
 
     class pmc_heu {
         public:
-            std::vector<int>* E;
-            std::vector<long long>* V;
+            std::vector<int> const* E;
+            std::vector<long long> const* V;
             std::vector<int>* K;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -20,6 +20,7 @@
 #ifndef PMC_HEU_H_
 #define PMC_HEU_H_
 
+#include "pmc/pmc_bool_vector.h"
 #include "pmc_graph.h"
 #include "pmc_input.h"
 #include "pmc_utils.h"
@@ -77,12 +78,12 @@ namespace pmc {
                 return (v.get_bound() < u.get_bound());
             }
 
-            int search(pmc_graph& graph, std::vector<int>& C_max);
-            int search_cores(pmc_graph& graph, std::vector<int>& C_max, int lb);
-            int search_bounds(pmc_graph& graph, std::vector<int>& C_max);
+            int search(const pmc_graph& graph, std::vector<int>& C_max);
+            int search_cores(const pmc_graph& graph, std::vector<int>& C_max, int lb);
+            int search_bounds(const pmc_graph& graph, std::vector<int>& C_max);
 
             inline void branch(std::vector<Vertex>& P, int sz,
-                    int& mc, std::vector<int>& C, std::vector<short>& ind);
+                    int& mc, std::vector<int>& C, bool_vector& ind);
 
             void print_info(const std::vector<int>& C_max) const;
     };

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -20,25 +20,27 @@
 #ifndef PMC_HEU_H_
 #define PMC_HEU_H_
 
-#include "pmc_headers.h"
 #include "pmc_graph.h"
-#include "pmc_utils.h"
+#include "pmc_headers.h"
 #include "pmc_input.h"
+#include "pmc_utils.h"
 #include "pmc_vertex.h"
-#include <algorithm>
+
+#include <string>
+#include <vector>
 
 namespace pmc {
 
     class pmc_heu {
         public:
-            vector<int>* E;
-            vector<long long>* V;
-            vector<int>* K;
-            vector<int>* order;
-            vector<int>* degree;
+            std::vector<int>* E;
+            std::vector<long long>* V;
+            std::vector<int>* K;
+            std::vector<int>* order;
+            std::vector<int>* degree;
             double sec;
             int ub;
-            string strat;
+            std::string strat;
 
             int num_threads;
 
@@ -64,8 +66,8 @@ namespace pmc {
                 srand (time(NULL));
             };
 
-            int strategy(vector<int>& P);
-            void set_strategy(string s) { strat = s; }
+            int strategy(std::vector<int>& P);
+            void set_strategy(std::string s) { strat = s; }
             int compute_heuristic(int v);
 
             static bool desc_heur(Vertex v,  Vertex u) {
@@ -76,14 +78,14 @@ namespace pmc {
                 return (v.get_bound() < u.get_bound());
             }
 
-            int search(pmc_graph& graph, vector<int>& C_max);
-            int search_cores(pmc_graph& graph, vector<int>& C_max, int lb);
-            int search_bounds(pmc_graph& graph, vector<int>& C_max);
+            int search(pmc_graph& graph, std::vector<int>& C_max);
+            int search_cores(pmc_graph& graph, std::vector<int>& C_max, int lb);
+            int search_bounds(pmc_graph& graph, std::vector<int>& C_max);
 
-            inline void branch(vector<Vertex>& P, int sz,
-                    int& mc, vector<int>& C, vector<short>& ind);
+            inline void branch(std::vector<Vertex>& P, int sz,
+                    int& mc, std::vector<int>& C, std::vector<short>& ind);
 
-            inline void print_info(vector<int> C_max);
+            inline void print_info(std::vector<int> C_max);
     };
 };
 #endif

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -21,7 +21,6 @@
 #define PMC_HEU_H_
 
 #include "pmc_graph.h"
-#include "pmc_headers.h"
 #include "pmc_input.h"
 #include "pmc_utils.h"
 #include "pmc_vertex.h"

--- a/include/pmc/pmc_heu.h
+++ b/include/pmc/pmc_heu.h
@@ -84,7 +84,7 @@ namespace pmc {
             inline void branch(std::vector<Vertex>& P, int sz,
                     int& mc, std::vector<int>& C, std::vector<short>& ind);
 
-            inline void print_info(std::vector<int> C_max);
+            void print_info(const std::vector<int>& C_max) const;
     };
 };
 #endif

--- a/include/pmc/pmc_input.h
+++ b/include/pmc/pmc_input.h
@@ -20,10 +20,10 @@
 #ifndef PMC_INPUT_H_
 #define PMC_INPUT_H_
 
-#include "pmc_headers.h"
 #include "pmc_utils.h"
 
 #include <iostream>
+#include <omp.h>
 #include <string>
 #include <unistd.h>
 

--- a/include/pmc/pmc_input.h
+++ b/include/pmc/pmc_input.h
@@ -23,7 +23,9 @@
 #include "pmc_headers.h"
 #include "pmc_utils.h"
 
-using namespace std;
+#include <iostream>
+#include <string>
+#include <unistd.h>
 
 namespace pmc {
 class input {
@@ -43,12 +45,12 @@ class input {
         bool help;
         bool MCE;
         bool decreasing_order;
-        string heu_strat;
-        string format;
-        string graph;
-        string output;
-        string edge_sorter;
-        string vertex_search_order;
+        std::string heu_strat;
+        std::string format;
+        std::string graph;
+        std::string output;
+        std::string edge_sorter;
+        std::string vertex_search_order;
 
         input() {
             // default values
@@ -71,7 +73,7 @@ class input {
             format = "mtx";
             graph = "data/sample.mtx";
             output = "";
-            string edge_sorter = "";
+            std::string edge_sorter = "";
 
             // both off, use default alg
             if (heu_strat == "0" && algorithm == -1)
@@ -101,7 +103,7 @@ class input {
             format = "mtx";
             graph = "data/sample.mtx";
             output = "";
-            string edge_sorter = "";
+            std::string edge_sorter = "";
 
             int opt;
             while ((opt=getopt(argc,argv,"i:t:f:u:l:o:e:a:r:w:h:k:dgsv")) != EOF) {
@@ -179,12 +181,12 @@ class input {
             }
             fclose(fin);
 
-            cout << "\n\nFile Name ------------------------ " << graph.c_str() << endl;
+            std::cout << "\n\nFile Name ------------------------ " << graph.c_str() << std::endl;
             if (!fexists(graph.c_str()) ) {
-                cout << "File not found!" << endl;
+                std::cout << "File not found!" << std::endl;
                 return;
             }
-            cout << "workers: " << threads <<endl;
+            std::cout << "workers: " << threads <<std::endl;
             omp_set_num_threads(threads);
         }
 

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -109,7 +109,7 @@ namespace pmc {
                     std::vector<int>& C_max,
                     int* &pruned,
                     int& mc,
-                    std::vector<std::vector<bool>> &adj);
+                    std::vector<std::vector<std::uint8_t>> &adj);
 
     };
 };

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -21,12 +21,10 @@
 #define PMC_MAXCLIQUE_H_
 
 #include "pmc_graph.h"
-#include "pmc_headers.h"
 #include "pmc_input.h"
 #include "pmc_utils.h"
 #include "pmc_vertex.h"
 
-#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -111,7 +109,7 @@ namespace pmc {
                     std::vector<int>& C_max,
                     int* &pruned,
                     int& mc,
-                    vector<vector<bool>> &adj);
+                    std::vector<std::vector<bool>> &adj);
 
     };
 };

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -20,28 +20,25 @@
 #ifndef PMC_MAXCLIQUE_H_
 #define PMC_MAXCLIQUE_H_
 
-#include <cstddef>
-#include <sys/time.h>
-#include <unistd.h>
-#include <iostream>
-#include <algorithm>
-#include "pmc_headers.h"
-#include "pmc_utils.h"
 #include "pmc_graph.h"
+#include "pmc_headers.h"
 #include "pmc_input.h"
+#include "pmc_utils.h"
 #include "pmc_vertex.h"
 
-using namespace std;
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace pmc {
 
     class pmc_maxclique {
         public:
-            vector<int>* edges;
-            vector<long long>* vertices;
-            vector<int>* bound;
-            vector<int>* order;
-            vector<int>* degree;
+            std::vector<int>* edges;
+            std::vector<long long>* vertices;
+            std::vector<int>* bound;
+            std::vector<int>* order;
+            std::vector<int>* degree;
             int param_ub;
             int ub;
             int lb;
@@ -52,7 +49,7 @@ namespace pmc {
             bool time_expired_msg;
             bool decr_order;
 
-            string vertex_ordering;
+            std::string vertex_ordering;
             int edge_ordering;
             int style_bounds;
             int style_dynamic_bounds;
@@ -94,24 +91,24 @@ namespace pmc {
 
             ~pmc_maxclique() {};
 
-            int search(pmc_graph& G, vector<int>& sol);
+            int search(pmc_graph& G, std::vector<int>& sol);
 
             void branch(
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
                     int* &pruned,
                     int& mc);
 
 
-            int search_dense(pmc_graph& G, vector<int>& sol);
+            int search_dense(pmc_graph& G, std::vector<int>& sol);
 
             void branch_dense(
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
                     int* &pruned,
                     int& mc,
                     vector<vector<bool>> &adj);

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc);
 
 
@@ -107,7 +107,7 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    std::vector<int>& pruned,
+                    const std::vector<std::uint8_t>& pruned,
                     int& mc);
 
 
@@ -107,7 +107,7 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    std::vector<int>& pruned,
+                    std::vector<std::uint8_t>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    const std::vector<std::uint8_t>& pruned,
+                    const bool_vector& pruned,
                     int& mc);
 
 
@@ -107,9 +107,9 @@ namespace pmc {
                     std::vector<short>& ind,
                     std::vector<int>& C,
                     std::vector<int>& C_max,
-                    std::vector<std::uint8_t>& pruned,
+                    bool_vector& pruned,
                     int& mc,
-                    std::vector<std::vector<std::uint8_t>> &adj);
+                    std::vector<bool_vector>& adj);
 
     };
 };

--- a/include/pmc/pmc_maxclique.h
+++ b/include/pmc/pmc_maxclique.h
@@ -32,8 +32,8 @@ namespace pmc {
 
     class pmc_maxclique {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
+            std::vector<int> const* edges;
+            std::vector<long long> const* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -94,7 +94,7 @@ namespace pmc {
             std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
             int& mc,
-            vector<vector<bool>> &adj) {
+            std::vector<std::vector<bool>> &adj) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;
         int max_k = 1;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -36,7 +36,7 @@ namespace pmc {
             std::vector<int>& C,
             std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
-            int* pruned,
+            std::vector<int>& pruned,
             int& mc) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -22,19 +22,19 @@
 
 #include "pmc_vertex.h"
 
-using namespace std;
+#include <vector>
 
 namespace pmc {
 
     // sequential dynamic greedy coloring and sort
     static void neigh_coloring_bound(
-            vector<long long>& vs,
-            vector<int>& es,
-            vector<Vertex> &P,
-            vector<short>& ind,
-            vector<int>& C,
-            vector<int>& C_max,
-            vector< vector<int> >& colors,
+            std::vector<long long>& vs,
+            std::vector<int>& es,
+            std::vector<Vertex> &P,
+            std::vector<short>& ind,
+            std::vector<int>& C,
+            std::vector<int>& C_max,
+            std::vector< std::vector<int> >& colors,
             int* pruned,
             int& mc) {
 
@@ -86,13 +86,13 @@ namespace pmc {
 
     // sequential dynamic greedy coloring and sort
     static void neigh_coloring_dense(
-            vector<long long>& vs,
-            vector<int>& es,
-            vector<Vertex> &P,
-            vector<short>& ind,
-            vector<int>& C,
-            vector<int>& C_max,
-            vector< vector<int> >& colors,
+            std::vector<long long>& vs,
+            std::vector<int>& es,
+            std::vector<Vertex> &P,
+            std::vector<short>& ind,
+            std::vector<int>& C,
+            std::vector<int>& C_max,
+            std::vector< std::vector<int> >& colors,
             int& mc,
             vector<vector<bool>> &adj) {
 

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -20,9 +20,9 @@
 #ifndef PMC_NEIGH_COLORING_H_
 #define PMC_NEIGH_COLORING_H_
 
+#include "pmc/pmc_bool_vector.h"
 #include "pmc_vertex.h"
 
-#include <cstdint>
 #include <vector>
 
 namespace pmc {
@@ -94,7 +94,7 @@ namespace pmc {
             std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
             int& mc,
-            std::vector<std::vector<std::uint8_t>> &adj) {
+            std::vector<bool_vector>& adj) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;
         int max_k = 1;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -22,6 +22,7 @@
 
 #include "pmc_vertex.h"
 
+#include <cstdint>
 #include <vector>
 
 namespace pmc {
@@ -94,7 +95,7 @@ namespace pmc {
             std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
             int& mc,
-            std::vector<std::vector<bool>> &adj) {
+            std::vector<std::vector<std::uint8_t>> &adj) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;
         int max_k = 1;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -34,7 +34,6 @@ namespace pmc {
             std::vector<Vertex> &P,
             std::vector<short>& ind,
             std::vector<int>& C,
-            std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
             int& mc) {
 
@@ -86,15 +85,11 @@ namespace pmc {
 
     // sequential dynamic greedy coloring and sort
     static void neigh_coloring_dense(
-            std::vector<long long>& vs,
-            std::vector<int>& es,
             std::vector<Vertex> &P,
-            std::vector<short>& ind,
             std::vector<int>& C,
-            std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
             int& mc,
-            std::vector<bool_vector>& adj) {
+            const std::vector<bool_vector>& adj) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;
         int max_k = 1;

--- a/include/pmc/pmc_neigh_coloring.h
+++ b/include/pmc/pmc_neigh_coloring.h
@@ -36,7 +36,6 @@ namespace pmc {
             std::vector<int>& C,
             std::vector<int>& C_max,
             std::vector< std::vector<int> >& colors,
-            std::vector<int>& pruned,
             int& mc) {
 
         int j = 0, u = 0, k = 1, k_prev = 0;

--- a/include/pmc/pmc_neigh_cores.h
+++ b/include/pmc/pmc_neigh_cores.h
@@ -22,24 +22,24 @@
 
 #include "pmc_vertex.h"
 
-using namespace std;
+#include <vector>
 
 namespace pmc {
 
     static void neigh_cores_bound(
-            vector<long long>& vs,
-            vector<int>& es,
-            vector<Vertex> &P,
-            vector<short>& ind,
+            std::vector<long long>& vs,
+            std::vector<int>& es,
+            std::vector<Vertex> &P,
+            std::vector<short>& ind,
             int& mc) {
 
         int n = P.size() + 1;
 
         // lookup table
-        vector<int> newids_to_actual(n, 0);
-        vector<int> vert_order(n,0);
-        vector<int> deg(n,0);
-        vector<int> pos(n,0);
+        std::vector<int> newids_to_actual(n, 0);
+        std::vector<int> vert_order(n,0);
+        std::vector<int> deg(n,0);
+        std::vector<int> pos(n,0);
 
         // lookup table for neighbors
         for (int v = 1; v < n; v++) ind[P[v-1].get_id()] = 1;
@@ -57,7 +57,7 @@ namespace pmc {
         }
 
         int md_end = md+1;
-        vector<int> bin(md_end,0);
+        std::vector<int> bin(md_end,0);
         for (int v = 1; v < n; v++) bin[deg[v]]++;
 
         int start = 1, num = 0;
@@ -131,19 +131,19 @@ namespace pmc {
 
 
     static void neigh_cores_tight(
-            vector<long long>& vs,
-            vector<int>& es,
-            vector<Vertex> &P,
-            vector<short>& ind,
+            std::vector<long long>& vs,
+            std::vector<int>& es,
+            std::vector<Vertex> &P,
+            std::vector<short>& ind,
             int& mc) {
 
         int n = P.size() + 1;
 
         // lookup table
-        vector<int> newids_to_actual(n, 0);
-        vector<int> vert_order(n,0);
-        vector<int> deg(n,0);
-        vector<int> pos(n,0);
+        std::vector<int> newids_to_actual(n, 0);
+        std::vector<int> vert_order(n,0);
+        std::vector<int> deg(n,0);
+        std::vector<int> pos(n,0);
 
 
         // lookup table for neighbors
@@ -168,7 +168,7 @@ namespace pmc {
         }
 
         int md_end = md+1;
-        vector<int> bin(md_end,0);
+        std::vector<int> bin(md_end,0);
         for (int v = 1; v < n; v++) bin[deg[v]]++;
 
         int start = 1, num = 0;

--- a/include/pmc/pmc_utils.h
+++ b/include/pmc/pmc_utils.h
@@ -21,33 +21,23 @@
 #define PMC_UTILS_H_
 
 #include <cstddef>
-#include <sys/time.h>
-#include <unistd.h>
-#include <iostream>
-#include "assert.h"
-#include <sys/types.h>
-#include <dirent.h>
-#include <errno.h>
-#include <string>
 #include <set>
-#include "pmc_headers.h"
-
-
-using namespace std;
+#include <string>
+#include <vector>
 
 bool fexists(const char *filename);
 void usage(char *argv0);
 
 double get_time();
-string memory_usage();
+std::string memory_usage();
 
-void validate(bool condition, const string& msg);
+void validate(bool condition, const std::string &msg);
 
 void indent(int level);
-void indent(int level, string str);
-void print_max_clique(vector<int>& max_clique_data);
-void print_n_maxcliques(set< vector<int> > C, int n);
+void indent(int level, std::string str);
+void print_max_clique(std::vector<int> &max_clique_data);
+void print_n_maxcliques(std::set<std::vector<int>> C, int n);
 
-int getdir (string dir, vector<string> &files);
+int getdir(std::string dir, std::vector<std::string> &files);
 
 #endif

--- a/include/pmc/pmc_utils.h
+++ b/include/pmc/pmc_utils.h
@@ -20,7 +20,6 @@
 #ifndef PMC_UTILS_H_
 #define PMC_UTILS_H_
 
-#include <cstddef>
 #include <set>
 #include <string>
 #include <vector>

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -31,12 +31,12 @@ namespace pmc {
         private:
             int id, b;
         public:
-            Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {};
+            Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {}
 
-            void set_id(int vid) { id = vid; }
+            void set_id(int vid) noexcept { id = vid; }
             int get_id() const noexcept { return id; }
 
-            void set_bound(int value) { b = value; }
+            void set_bound(int value) noexcept { b = value; }
             int get_bound() const noexcept { return b; }
     };
 
@@ -47,7 +47,7 @@ namespace pmc {
         return (v.get_bound() < u.get_bound());
     };
 
-    inline static void print_mc_info(std::vector<int> &C_max, double sec) {
+    inline static void print_mc_info(const std::vector<int>& C_max, double sec) {
         DEBUG_PRINTF("*** [pmc: thread %i", omp_get_thread_num() + 1);
         DEBUG_PRINTF("]   current max clique = %i", C_max.size());
         DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -20,6 +20,7 @@
 #ifndef PMC_VERTEX_H_
 #define PMC_VERTEX_H_
 
+#include "pmc/pmc_utils.h"
 #include "pmc_debug_utils.h"
 
 #include <vector>
@@ -46,7 +47,7 @@ namespace pmc {
         return (v.get_bound() < u.get_bound());
     };
 
-    inline static void print_mc_info(std::vector<int> &C_max, double &sec) {
+    inline static void print_mc_info(std::vector<int> &C_max, double sec) {
         DEBUG_PRINTF("*** [pmc: thread %i", omp_get_thread_num() + 1);
         DEBUG_PRINTF("]   current max clique = %i", C_max.size());
         DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -33,11 +33,11 @@ namespace pmc {
         public:
             Vertex(int vertex_id, int bound): id(vertex_id), b(bound) {};
 
-            void set_id(int vid)        { id = vid; }
-            int get_id()                { return id; }
+            void set_id(int vid) { id = vid; }
+            int get_id() const noexcept { return id; }
 
-            void set_bound(int value)   { b = value; }
-            int get_bound()             { return b; }
+            void set_bound(int value) { b = value; }
+            int get_bound() const noexcept { return b; }
     };
 
     static bool decr_bound(Vertex v,  Vertex u) {

--- a/include/pmc/pmc_vertex.h
+++ b/include/pmc/pmc_vertex.h
@@ -22,7 +22,8 @@
 
 #include "pmc_debug_utils.h"
 
-using namespace std;
+#include <vector>
+#include <omp.h>
 
 namespace pmc {
     class Vertex {
@@ -45,7 +46,7 @@ namespace pmc {
         return (v.get_bound() < u.get_bound());
     };
 
-    inline static void print_mc_info(vector<int> &C_max, double &sec) {
+    inline static void print_mc_info(std::vector<int> &C_max, double &sec) {
         DEBUG_PRINTF("*** [pmc: thread %i", omp_get_thread_num() + 1);
         DEBUG_PRINTF("]   current max clique = %i", C_max.size());
         DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<std::uint8_t>& pruned,
+                    bool_vector& pruned,
                     int& mc);
 
             int search_dense(pmc_graph& G, std::vector<int>& sol);
@@ -108,9 +108,9 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<std::uint8_t>& pruned,
+                    bool_vector& pruned,
                     int& mc,
-                    std::vector<std::vector<std::uint8_t>> &adj);
+                    std::vector<bool_vector>& adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<int>& pruned,
+                    std::vector<std::uint8_t>& pruned,
                     int& mc);
 
             int search_dense(pmc_graph& G, std::vector<int>& sol);
@@ -108,7 +108,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<int>& pruned,
+                    std::vector<std::uint8_t>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    bool_vector& pruned,
+                    const bool_vector& pruned,
                     int& mc);
 
             int search_dense(pmc_graph& G, std::vector<int>& sol);
@@ -108,9 +108,9 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    bool_vector& pruned,
+                    const bool_vector& pruned,
                     int& mc,
-                    std::vector<bool_vector>& adj);
+                    const std::vector<bool_vector>& adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -96,7 +96,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc);
 
             int search_dense(pmc_graph& G, std::vector<int>& sol);
@@ -108,7 +108,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -21,14 +21,10 @@
 #define PMCX_MAXCLIQUE_H_
 
 #include "pmc_graph.h"
-#include "pmc_headers.h"
 #include "pmc_input.h"
-#include "pmc_neigh_coloring.h"
-#include "pmc_neigh_cores.h"
 #include "pmc_utils.h"
 #include "pmc_vertex.h"
 
-#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -114,7 +110,7 @@ namespace pmc {
                     std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
-                    vector<vector<bool>> &adj);
+                    std::vector<std::vector<bool>> &adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -20,29 +20,26 @@
 #ifndef PMCX_MAXCLIQUE_H_
 #define PMCX_MAXCLIQUE_H_
 
-#include <cstddef>
-#include <sys/time.h>
-#include <unistd.h>
-#include <iostream>
-#include "pmc_headers.h"
-#include "pmc_utils.h"
 #include "pmc_graph.h"
+#include "pmc_headers.h"
 #include "pmc_input.h"
-#include "pmc_vertex.h"
-#include "pmc_neigh_cores.h"
 #include "pmc_neigh_coloring.h"
-#include <algorithm>
+#include "pmc_neigh_cores.h"
+#include "pmc_utils.h"
+#include "pmc_vertex.h"
 
-using namespace std;
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace pmc {
 
     class pmcx_maxclique {
         public:
-            vector<int>* edges;
-            vector<long long>* vertices;
-            vector<int>* bound;
-            vector<int>* order;
+            std::vector<int>* edges;
+            std::vector<long long>* vertices;
+            std::vector<int>* bound;
+            std::vector<int>* order;
             int param_ub;
             int ub;
             int lb;
@@ -53,7 +50,7 @@ namespace pmc {
             bool time_expired_msg;
             bool decr_order;
 
-            string vertex_ordering;
+            std::string vertex_ordering;
             int edge_ordering;
             int style_bounds;
             int style_dynamic_bounds;
@@ -94,27 +91,27 @@ namespace pmc {
 
             ~pmcx_maxclique() {};
 
-            int search(pmc_graph& G, vector<int>& sol);
+            int search(pmc_graph& G, std::vector<int>& sol);
             inline void branch(
-                    vector<long long>& vs,
-                    vector<int>& es,
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
-                    vector< vector<int> >& colors,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
+                    std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc);
 
-            int search_dense(pmc_graph& G, vector<int>& sol);
+            int search_dense(pmc_graph& G, std::vector<int>& sol);
             inline void branch_dense(
-                    vector<long long>& vs,
-                    vector<int>& es,
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
-                    vector< vector<int> >& colors,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
+                    std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
                     vector<vector<bool>> &adj);

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -32,8 +32,6 @@ namespace pmc {
 
     class pmcx_maxclique {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             int param_ub;

--- a/include/pmc/pmcx_maxclique.h
+++ b/include/pmc/pmcx_maxclique.h
@@ -110,7 +110,7 @@ namespace pmc {
                     std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
-                    std::vector<std::vector<bool>> &adj);
+                    std::vector<std::vector<std::uint8_t>> &adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -99,7 +99,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    const std::vector<std::uint8_t>& pruned,
+                    const bool_vector& pruned,
                     int& mc);
 
 
@@ -113,9 +113,9 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<std::uint8_t>& pruned,
+                    bool_vector& pruned,
                     int& mc,
-                    std::vector<std::vector<std::uint8_t>> &adj);
+                    std::vector<bool_vector>& adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -20,30 +20,27 @@
 #ifndef PMCX_MAXCLIQUE_BASIC_H_
 #define PMCX_MAXCLIQUE_BASIC_H_
 
-#include <cstddef>
-#include <sys/time.h>
-#include <unistd.h>
-#include <iostream>
-#include <algorithm>
-#include "pmc_headers.h"
-#include "pmc_utils.h"
 #include "pmc_graph.h"
+#include "pmc_headers.h"
 #include "pmc_input.h"
-#include "pmc_vertex.h"
-#include "pmc_neigh_cores.h"
 #include "pmc_neigh_coloring.h"
+#include "pmc_neigh_cores.h"
+#include "pmc_utils.h"
+#include "pmc_vertex.h"
 
-using namespace std;
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace pmc {
 
     class pmcx_maxclique_basic {
         public:
-            vector<int>* edges;
-            vector<long long>* vertices;
-            vector<int>* bound;
-            vector<int>* order;
-            vector<int>* degree;
+            std::vector<int>* edges;
+            std::vector<long long>* vertices;
+            std::vector<int>* bound;
+            std::vector<int>* order;
+            std::vector<int>* degree;
             int param_ub;
             int ub;
             int lb;
@@ -54,7 +51,7 @@ namespace pmc {
             bool time_expired_msg;
             bool decr_order;
 
-            string vertex_ordering;
+            std::string vertex_ordering;
             int edge_ordering;
             int style_bounds;
             int style_dynamic_bounds;
@@ -96,30 +93,30 @@ namespace pmc {
 
             ~pmcx_maxclique_basic() {};
 
-            int search(pmc_graph& G, vector<int>& sol);
+            int search(pmc_graph& G, std::vector<int>& sol);
 
             void branch(
-                    vector<long long>& vs,
-                    vector<int>& es,
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
-                    vector< vector<int> >& colors,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
+                    std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc);
 
 
-            int search_dense(pmc_graph& G, vector<int>& sol);
+            int search_dense(pmc_graph& G, std::vector<int>& sol);
 
             void branch_dense(
-                    vector<long long>& vs,
-                    vector<int>& es,
-                    vector<Vertex> &P,
-                    vector<short>& ind,
-                    vector<int>& C,
-                    vector<int>& C_max,
-                    vector< vector<int> >& colors,
+                    std::vector<long long>& vs,
+                    std::vector<int>& es,
+                    std::vector<Vertex> &P,
+                    std::vector<short>& ind,
+                    std::vector<int>& C,
+                    std::vector<int>& C_max,
+                    std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
                     vector<vector<bool>> &adj);

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -32,8 +32,6 @@ namespace pmc {
 
     class pmcx_maxclique_basic {
         public:
-            std::vector<int>* edges;
-            std::vector<long long>* vertices;
             std::vector<int>* bound;
             std::vector<int>* order;
             std::vector<int>* degree;

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -99,7 +99,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc);
 
 
@@ -113,7 +113,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    int* &pruned,
+                    std::vector<int>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -99,7 +99,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<int>& pruned,
+                    const std::vector<std::uint8_t>& pruned,
                     int& mc);
 
 
@@ -113,7 +113,7 @@ namespace pmc {
                     std::vector<int>& C,
                     std::vector<int>& C_max,
                     std::vector< std::vector<int> >& colors,
-                    std::vector<int>& pruned,
+                    std::vector<std::uint8_t>& pruned,
                     int& mc,
                     std::vector<std::vector<std::uint8_t>> &adj);
 

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -21,14 +21,10 @@
 #define PMCX_MAXCLIQUE_BASIC_H_
 
 #include "pmc_graph.h"
-#include "pmc_headers.h"
 #include "pmc_input.h"
-#include "pmc_neigh_coloring.h"
-#include "pmc_neigh_cores.h"
 #include "pmc_utils.h"
 #include "pmc_vertex.h"
 
-#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -119,7 +115,7 @@ namespace pmc {
                     std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
-                    vector<vector<bool>> &adj);
+                    std::vector<std::vector<bool>> &adj);
 
     };
 };

--- a/include/pmc/pmcx_maxclique_basic.h
+++ b/include/pmc/pmcx_maxclique_basic.h
@@ -115,7 +115,7 @@ namespace pmc {
                     std::vector< std::vector<int> >& colors,
                     int* &pruned,
                     int& mc,
-                    std::vector<std::vector<bool>> &adj);
+                    std::vector<std::vector<std::uint8_t>> &adj);
 
     };
 };

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -127,9 +127,7 @@ void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
         const bool_vector& pruned,
-        pmc_graph& G,
-        int id,
-        int& mc) {
+        pmc_graph& G) {
 
     int num_vs = vs.size();
 

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -28,7 +28,7 @@
 using namespace std;
 using namespace pmc;
 
-int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb) {
+int pmc_graph::initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -48,7 +48,7 @@ int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb) {
 }
 
 
-int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
+int pmc_graph::initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -127,7 +127,7 @@ void pmc_graph::order_vertices(vector<Vertex> &V, pmc_graph &G,
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        int* &pruned,
+        std::vector<int>& pruned,
         pmc_graph& G,
         int id,
         int& mc) {

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -22,6 +22,7 @@
 #include "pmc/pmc_utils.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 
 using namespace std;
@@ -47,7 +48,7 @@ int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb) {
 }
 
 
-int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb, vector<vector<bool>> &adj) {
+int pmc_graph::initial_pruning(pmc_graph& G, int* &pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -28,7 +28,7 @@
 using namespace std;
 using namespace pmc;
 
-int pmc_graph::initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb) {
+int pmc_graph::initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -48,7 +48,7 @@ int pmc_graph::initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb) {
 }
 
 
-int pmc_graph::initial_pruning(pmc_graph& G, std::vector<int>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
+int pmc_graph::initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -127,7 +127,7 @@ void pmc_graph::order_vertices(vector<Vertex> &V, pmc_graph &G,
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        std::vector<int>& pruned,
+        const std::vector<std::uint8_t>& pruned,
         pmc_graph& G,
         int id,
         int& mc) {
@@ -157,7 +157,7 @@ void pmc_graph::reduce_graph(
     #pragma omp single nowait
     {
         cout << ">>> [pmc: thread " << omp_get_thread_num() + 1 << "]" <<endl;
-        G.induced_cores_ordering(vs,es,pruned);
+        G.induced_cores_ordering(vs,es);
     }
     V.clear();
     E.clear();

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -22,13 +22,12 @@
 #include "pmc/pmc_utils.h"
 
 #include <algorithm>
-#include <cstdint>
 #include <iostream>
 
 using namespace std;
 using namespace pmc;
 
-int pmc_graph::initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb) {
+int pmc_graph::initial_pruning(pmc_graph& G, bool_vector& pruned, int lb) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -48,7 +47,7 @@ int pmc_graph::initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, 
 }
 
 
-int pmc_graph::initial_pruning(pmc_graph& G, std::vector<std::uint8_t>& pruned, int lb, std::vector<std::vector<std::uint8_t>> &adj) {
+int pmc_graph::initial_pruning(pmc_graph& G, bool_vector& pruned, int lb, std::vector<bool_vector>& adj) {
     int lb_idx = 0;
     for (int i = G.num_vertices()-1; i >= 0; i--) {
         if (kcore[kcore_order[i]] == lb)  lb_idx = i;
@@ -127,7 +126,7 @@ void pmc_graph::order_vertices(vector<Vertex> &V, pmc_graph &G,
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        const std::vector<std::uint8_t>& pruned,
+        const bool_vector& pruned,
         pmc_graph& G,
         int id,
         int& mc) {

--- a/pmc_clique_utils.cpp
+++ b/pmc_clique_utils.cpp
@@ -19,7 +19,10 @@
 
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_graph.h"
+#include "pmc/pmc_utils.h"
+
 #include <algorithm>
+#include <iostream>
 
 using namespace std;
 using namespace pmc;

--- a/pmc_cores.cpp
+++ b/pmc_cores.cpp
@@ -24,8 +24,7 @@ using namespace std;
 
 void pmc_graph::induced_cores_ordering(
         vector<long long>& V,
-        vector<int>& E,
-        std::vector<int>& pruned) {
+        vector<int>& E) {
 
     long long n, d, i, j, start, num, md;
     long long v, u, w, du, pu, pw, md_end;

--- a/pmc_cores.cpp
+++ b/pmc_cores.cpp
@@ -25,7 +25,7 @@ using namespace std;
 void pmc_graph::induced_cores_ordering(
         vector<long long>& V,
         vector<int>& E,
-        int* &pruned) {
+        std::vector<int>& pruned) {
 
     long long n, d, i, j, start, num, md;
     long long v, u, w, du, pu, pw, md_end;

--- a/pmc_cores.cpp
+++ b/pmc_cores.cpp
@@ -20,6 +20,7 @@
 #include "pmc/pmc_graph.h"
 
 using namespace pmc;
+using namespace std;
 
 void pmc_graph::induced_cores_ordering(
         vector<long long>& V,

--- a/pmc_driver.cpp
+++ b/pmc_driver.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
 
     //! read graph
     pmc_graph G(in.graph_stats,in.graph);
-    if (in.graph_stats) { G.bound_stats(in.algorithm, in.lb, G); }
+    if (in.graph_stats) { G.bound_stats(in.algorithm); }
 
     //! ensure wait time is greater than the time to recompute the graph data structures
     if (G.num_edges() > 1000000000 && in.remove_time < 120)  in.remove_time = 120;

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -95,7 +95,7 @@ void pmc_graph::read_edges(const string& filename) {
     istringstream in_stream;
     string line = "";
     map< int, vector<int> > vert_list;
-    int v = 0, u = 0, num_es = 0, self_edges = 0;
+    int v = 0, u = 0, self_edges = 0;
 
     ifstream in_check (filename.c_str());
     if (!in_check) { cout << filename << "File not found!" <<endl; return; }
@@ -120,7 +120,6 @@ void pmc_graph::read_edges(const string& filename) {
     while (!in.eof()) {
         getline(in,line);
         if (line[0] == '%' || line[0] == '#') continue;
-        num_es++;
         if (line != "") {
             in_stream.clear();
             in_stream.str(line);
@@ -276,8 +275,6 @@ void pmc_graph::read_mtx(const string& filename) {
     vertex_degrees();
 }
 
-void pmc_graph::read_metis(const string& filename) { return; };
-
 void pmc_graph::create_adj() {
     double sec = get_time();
 
@@ -332,7 +329,7 @@ void pmc_graph::update_degrees() {
         degree[v] = vertices[v+1] - vertices[v];
 }
 
-void pmc_graph::update_degrees(bool flag) {
+void pmc_graph::update_degrees(bool /*flag*/) {
 
     int p = 0;
     max_degree = vertices[1] - vertices[0];
@@ -481,9 +478,7 @@ void pmc_graph::reduce_graph(const bool_vector& pruned) {
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        const bool_vector& pruned,
-        int id,
-        int& mc) {
+        const bool_vector& pruned) {
 
     int num_vs = vs.size();
 
@@ -508,7 +503,7 @@ void pmc_graph::reduce_graph(
 }
 
 
-void pmc_graph::bound_stats(int alg, int lb, pmc_graph& G) {
+void pmc_graph::bound_stats(int alg) {
     cout << "graph: " << fn <<endl;
     cout << "alg: " << alg <<endl;
     cout << "-------------------------------" <<endl;

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -348,14 +348,14 @@ void pmc_graph::update_degrees(bool flag) {
 }
 
 
-void pmc_graph::update_degrees(std::vector<std::uint8_t>& pruned, int& mc) {
+void pmc_graph::update_degrees(bool_vector& pruned, int& mc) {
     max_degree = -1;
     min_degree = std::numeric_limits<int>::max();
     int p = 0;
     for (long long v=0; v < num_vertices(); v++) {
         degree[v] = vertices[v+1] - vertices[v];
         if (degree[v] < mc) {
-            if (!pruned[v])  pruned[v] = 1;
+            if (!pruned[v])  pruned[v] = true;
             p++;
         }
         else {
@@ -368,7 +368,7 @@ void pmc_graph::update_degrees(std::vector<std::uint8_t>& pruned, int& mc) {
 }
 
 
-void pmc_graph::update_kcores(const std::vector<std::uint8_t>& pruned) {
+void pmc_graph::update_kcores(const bool_vector& pruned) {
 
     long long n, d, i, j, start, num, md;
     long long v, u, w, du, pu, pw, md_end;
@@ -456,7 +456,7 @@ string pmc_graph::get_file_extension(const string& filename) {
 
 
 
-void pmc_graph::reduce_graph(const std::vector<std::uint8_t>& pruned) {
+void pmc_graph::reduce_graph(const bool_vector& pruned) {
     vector<long long> V(vertices.size(),0);
     vector<int> E;
     E.reserve(edges.size());
@@ -481,7 +481,7 @@ void pmc_graph::reduce_graph(const std::vector<std::uint8_t>& pruned) {
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        const std::vector<std::uint8_t>& pruned,
+        const bool_vector& pruned,
         int id,
         int& mc) {
 

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -348,7 +348,7 @@ void pmc_graph::update_degrees(bool flag) {
 }
 
 
-void pmc_graph::update_degrees(int* &pruned, int& mc) {
+void pmc_graph::update_degrees(std::vector<int>& pruned, int& mc) {
     max_degree = -1;
     min_degree = std::numeric_limits<int>::max();
     int p = 0;
@@ -368,7 +368,7 @@ void pmc_graph::update_degrees(int* &pruned, int& mc) {
 }
 
 
-void pmc_graph::update_kcores(int* &pruned) {
+void pmc_graph::update_kcores(std::vector<int>& pruned) {
 
     long long n, d, i, j, start, num, md;
     long long v, u, w, du, pu, pw, md_end;
@@ -456,7 +456,7 @@ string pmc_graph::get_file_extension(const string& filename) {
 
 
 
-void pmc_graph::reduce_graph(int* &pruned) {
+void pmc_graph::reduce_graph(std::vector<int>& pruned) {
     vector<long long> V(vertices.size(),0);
     vector<int> E;
     E.reserve(edges.size());
@@ -481,7 +481,7 @@ void pmc_graph::reduce_graph(int* &pruned) {
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        int* &pruned,
+        std::vector<int>& pruned,
         int id,
         int& mc) {
 

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -348,7 +348,7 @@ void pmc_graph::update_degrees(bool flag) {
 }
 
 
-void pmc_graph::update_degrees(std::vector<int>& pruned, int& mc) {
+void pmc_graph::update_degrees(std::vector<std::uint8_t>& pruned, int& mc) {
     max_degree = -1;
     min_degree = std::numeric_limits<int>::max();
     int p = 0;
@@ -368,7 +368,7 @@ void pmc_graph::update_degrees(std::vector<int>& pruned, int& mc) {
 }
 
 
-void pmc_graph::update_kcores(std::vector<int>& pruned) {
+void pmc_graph::update_kcores(const std::vector<std::uint8_t>& pruned) {
 
     long long n, d, i, j, start, num, md;
     long long v, u, w, du, pu, pw, md_end;
@@ -456,7 +456,7 @@ string pmc_graph::get_file_extension(const string& filename) {
 
 
 
-void pmc_graph::reduce_graph(std::vector<int>& pruned) {
+void pmc_graph::reduce_graph(const std::vector<std::uint8_t>& pruned) {
     vector<long long> V(vertices.size(),0);
     vector<int> E;
     E.reserve(edges.size());
@@ -481,7 +481,7 @@ void pmc_graph::reduce_graph(std::vector<int>& pruned) {
 void pmc_graph::reduce_graph(
         vector<long long>& vs,
         vector<int>& es,
-        std::vector<int>& pruned,
+        const std::vector<std::uint8_t>& pruned,
         int id,
         int& mc) {
 

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -20,6 +20,8 @@
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_graph.h"
 
+#include <limits>
+
 using namespace pmc;
 using namespace std;
 
@@ -169,7 +171,7 @@ pmc_graph::pmc_graph(map<int,vector<int> > v_map) {
 }
 
 void pmc_graph::read_mtx(const string& filename) {
-    float connStrength = -DBL_MAX;
+    float connStrength = std::numeric_limits<float>::lowest();
     istringstream in2;
     string line="";
     map<int,vector<int> > v_map;

--- a/pmc_graph.cpp
+++ b/pmc_graph.cpp
@@ -18,9 +18,15 @@
  */
 
 #include "pmc/pmc_debug_utils.h"
+#include "pmc/pmc_utils.h"
 #include "pmc/pmc_graph.h"
+#include "pmc/pmc_headers.h"
 
+#include <cstring>
+#include <fstream>
+#include <iostream>
 #include <limits>
+#include <sstream>
 
 using namespace pmc;
 using namespace std;
@@ -161,10 +167,10 @@ pmc_graph::pmc_graph(long long nedges, const int *ei, const int *ej, int offset)
     vertex_degrees();
 }
 
-pmc_graph::pmc_graph(map<int,vector<int> > v_map) {
+pmc_graph::pmc_graph(const map<int, vector<int>>& v_map) {
   vertices.push_back(edges.size());
-  for (int i=0;i < v_map.size(); i++) {
-    edges.insert(edges.end(),v_map[i].begin(),v_map[i].end());
+  for (const auto& v_pair : v_map) {
+    edges.insert(edges.end(), v_pair.second.begin(), v_pair.second.end());
     vertices.push_back(edges.size());
   }
   vertex_degrees();

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -17,33 +17,33 @@
  ============================================================================
  */
 
+#include "pmc/pmc_bool_vector.h"
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_heu.h"
 
 #include <algorithm>
 
 using namespace pmc;
-using namespace std;
 
 
-void pmc_heu::branch(vector<Vertex>& P, int sz,
-        int& mc, vector<int>& C, vector<short>& ind) {
+void pmc_heu::branch(std::vector<Vertex>& P, int sz,
+        int& mc, std::vector<int>& C, bool_vector& ind) {
 
     if (P.size() > 0) {
 
         int u = P.back().get_id();
         P.pop_back();
 
-        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = 1;
+        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = true;
 
-        vector <Vertex> R;
+        std::vector <Vertex> R;
         R.reserve(P.size());
         for (int i = 0; i < P.size(); i++)
             if (ind[P[i].get_id()])
                 if ((*K)[P[i].get_id()] > mc)
                     R.push_back(P[i]);
 
-        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = 0;
+        for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = false;
 
         int mc_prev = mc;
         branch(R, sz + 1, mc, C, ind);
@@ -57,8 +57,8 @@ void pmc_heu::branch(vector<Vertex>& P, int sz,
     return;
 }
 
-int pmc_heu::search_bounds(pmc_graph& G,
-        vector<int>& C_max) {
+int pmc_heu::search_bounds(const pmc_graph& G,
+        std::vector<int>& C_max) {
 
     V = &G.get_vertices();
     E = &G.get_edges();
@@ -68,7 +68,7 @@ int pmc_heu::search_bounds(pmc_graph& G,
     std::vector<Vertex> P;
     P.reserve(G.get_max_degree()+1);
 
-    vector<short> ind(G.num_vertices(), 0);
+    bool_vector ind(G.num_vertices(), false);
 
     bool found_ub = false;
     int mc = 0, i;
@@ -122,15 +122,15 @@ int pmc_heu::compute_heuristic(int v) {
 }
 
 
-int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
+int pmc_heu::search_cores(const pmc_graph& G, std::vector<int>& C_max, int lb) {
 
-    vector <int> C, X;
+    std::vector <int> C, X;
     C.reserve(ub);
     C_max.reserve(ub);
-    vector<Vertex> P, T;
+    std::vector<Vertex> P, T;
     P.reserve(G.get_max_degree()+1);
     T.reserve(G.get_max_degree()+1);
-    vector<short> ind(G.num_vertices(),0);
+    bool_vector ind(G.num_vertices(), false);
 
     int mc = lb, i;
 
@@ -176,12 +176,12 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
 }
 
 
-int pmc_heu::search(pmc_graph& G, vector<int>& C_max) {
+int pmc_heu::search(const pmc_graph& G, std::vector<int>& C_max) {
     return search_bounds(G, C_max);
 }
 
 
-void pmc_heu::print_info(const vector<int>& C_max) const {
+void pmc_heu::print_info(const std::vector<int>& C_max) const {
     DEBUG_PRINTF("*** [pmc heuristic: thread %i", omp_get_thread_num() + 1);
     DEBUG_PRINTF("]   current max clique = %i", C_max.size());
     DEBUG_PRINTF(",  time = %i sec\n", get_time() - sec);

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -62,24 +62,24 @@ int pmc_heu::search_bounds(pmc_graph& G,
 
     V = &G.get_vertices();
     E = &G.get_edges();
-    vector <int> C, X;
+    std::vector<int> C;
     C.reserve(ub);
     C_max.reserve(ub);
-    vector<Vertex> P, T;
+    std::vector<Vertex> P;
     P.reserve(G.get_max_degree()+1);
-    T.reserve(G.get_max_degree()+1);
-    vector<short> ind(G.num_vertices(),0);
+
+    vector<short> ind(G.num_vertices(), 0);
 
     bool found_ub = false;
-    int mc = 0, i, v, lb_idx = 0;
+    int mc = 0, i;
 
     #pragma omp parallel for schedule(dynamic) \
-        shared(G, X, mc, C_max, lb_idx) private(i, v, P, C) firstprivate(ind) \
+        shared(G, mc, C_max) private(i, P, C) firstprivate(ind) \
         num_threads(num_threads)
     for (i = G.num_vertices()-1; i >= 0; --i) {
         if (found_ub) continue;
 
-        v = (*order)[i];
+        const int v = (*order)[i];
         const auto mc_prev = mc;
         auto mc_cur = mc_prev;
 
@@ -87,7 +87,6 @@ int pmc_heu::search_bounds(pmc_graph& G,
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
                 if ((*K)[(*E)[j]] > mc_cur)
                     P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
-
 
             if (P.size() > mc_cur) {
                 std::sort(P.begin(), P.end(), incr_heur);
@@ -104,7 +103,8 @@ int pmc_heu::search_bounds(pmc_graph& G,
                     }
                 }
             }
-            C = X; P = T;
+            C.clear();
+            P.clear();
         }
     }
     DEBUG_PRINTF("[pmc heuristic]\t mc = %i\n", mc);

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -81,12 +81,12 @@ int pmc_heu::search_bounds(pmc_graph& G,
         if (found_ub) continue;
 
         v = (*order)[i];
-        int mc_prev = mc;
-        int mc_cur = mc;
+        const auto mc_prev = mc;
+        auto mc_cur = mc_prev;
 
-        if ((*K)[v] > mc) {
+        if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
-                if ((*K)[(*E)[j]] > mc)
+                if ((*K)[(*E)[j]] > mc_cur)
                     P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
 
 
@@ -145,8 +145,8 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
     for (i = lb_idx; i <= G.num_vertices()-1; i++) {
 
         v = (*order)[i];
-        int mc_prev = mc;
-        int mc_cur = mc;
+        const auto mc_prev = mc;
+        auto mc_cur = mc_prev;
 
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -104,6 +104,11 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                 std::sort(P.begin(), P.end(), incr_heur);
                 branch(P, 1 , mc_cur, C, ind);
 
+                if (mc_cur >= ub) {
+                    #pragma omp atomic write release
+                    found_ub = true;
+                }
+
                 if (mc_cur > mc_prev) {
                     #pragma omp atomic read acquire
                     mc_prev = mc;
@@ -111,11 +116,6 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                     if (mc_cur > mc_prev) {
                         #pragma omp atomic write release
                         mc = mc_cur;
-
-                        if (mc_cur >= ub) {
-                            #pragma omp atomic write release
-                            found_ub = true;
-                        }
 
                         C.push_back(v);
 

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -104,11 +104,6 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                 std::sort(P.begin(), P.end(), incr_heur);
                 branch(P, 1 , mc_cur, C, ind);
 
-                if (mc_cur >= ub) {
-                    #pragma omp atomic write release
-                    found_ub = true;
-                }
-
                 if (mc_cur > mc_prev) {
                     #pragma omp atomic read acquire
                     mc_prev = mc;
@@ -116,6 +111,11 @@ int pmc_heu::search_bounds(const pmc_graph& G,
                     if (mc_cur > mc_prev) {
                         #pragma omp atomic write release
                         mc = mc_cur;
+
+                        if (mc_cur >= ub) {
+                            #pragma omp atomic write release
+                            found_ub = true;
+                        }
 
                         C.push_back(v);
 

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -20,6 +20,8 @@
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_heu.h"
 
+#include <algorithm>
+
 using namespace pmc;
 using namespace std;
 

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -60,9 +60,8 @@ void pmc_heu::branch(vector<Vertex>& P, int sz,
 int pmc_heu::search_bounds(pmc_graph& G,
         vector<int>& C_max) {
 
-    V = G.get_vertices();
-    E = G.get_edges();
-    degree = G.get_degree();
+    V = &G.get_vertices();
+    E = &G.get_edges();
     vector <int> C, X;
     C.reserve(ub);
     C_max.reserve(ub);
@@ -134,6 +133,7 @@ int pmc_heu::search_cores(pmc_graph& G, vector<int>& C_max, int lb) {
     vector<short> ind(G.num_vertices(),0);
 
     int mc = lb, i;
+
     int lb_idx = 0, v = 0;
     for (i = G.num_vertices()-1; i >= 0; i--) {
         v = (*order)[i];

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -29,28 +29,29 @@ using namespace pmc;
 void pmc_heu::branch(std::vector<Vertex>& P, int sz,
         int& mc, std::vector<int>& C, bool_vector& ind) {
 
-    if (P.size() > 0) {
+    if (!P.empty()) {
 
-        int u = P.back().get_id();
+        const int u = P.back().get_id();
         P.pop_back();
 
         for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = true;
 
-        std::vector <Vertex> R;
+        std::vector<Vertex> R;
         R.reserve(P.size());
-        for (int i = 0; i < P.size(); i++)
-            if (ind[P[i].get_id()])
-                if ((*K)[P[i].get_id()] > mc)
-                    R.push_back(P[i]);
+
+        std::copy_if(P.begin(), P.end(), std::back_inserter(R),
+                     [this, mc, &ind](const Vertex &v) -> bool {
+                       return ind[v.get_id()] && (*K)[v.get_id()] > mc;
+                     });
 
         for (long long j = (*V)[u]; j < (*V)[u + 1]; j++)  ind[(*E)[j]] = false;
 
-        int mc_prev = mc;
+        const int mc_prev = mc;
         branch(R, sz + 1, mc, C, ind);
 
         if (mc > mc_prev)  C.push_back(u);
 
-        R.clear();  P.clear();
+        P.clear();
     }
     else if (sz > mc)
         mc = sz;
@@ -89,7 +90,7 @@ int pmc_heu::search_bounds(const pmc_graph& G,
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
                 if ((*K)[(*E)[j]] > mc_cur)
-                    P.push_back( Vertex((*E)[j], compute_heuristic((*E)[j])) );
+                    P.emplace_back((*E)[j], compute_heuristic((*E)[j]));
 
             if (P.size() > mc_cur) {
                 std::sort(P.begin(), P.end(), incr_heur);

--- a/pmc_heu.cpp
+++ b/pmc_heu.cpp
@@ -90,8 +90,10 @@ int pmc_heu::search_bounds(const pmc_graph& G, std::vector<int>& C_max) {
         const int v = (*order)[i];
 
         int mc_prev, mc_cur;
-        #pragma omp atomic read acquire
-        mc_prev = mc_cur = mc;
+        {
+            #pragma omp critical
+            mc_prev = mc_cur = mc;
+        }
 
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
@@ -108,16 +110,12 @@ int pmc_heu::search_bounds(const pmc_graph& G, std::vector<int>& C_max) {
                 }
 
                 if (mc_cur > mc_prev) {
-                    #pragma omp atomic read acquire
-                    mc_prev = mc;
+                    C.push_back(v);
 
-                    if (mc_cur > mc_prev) {
-                        #pragma omp atomic write release
+                    #pragma omp critical
+                    if (mc_cur > mc) {
                         mc = mc_cur;
 
-                        C.push_back(v);
-
-                        #pragma omp critical
                         std::swap(C_max, C);
                         print_info(C_max);
                     }
@@ -167,8 +165,10 @@ int pmc_heu::search_cores(const pmc_graph& G, std::vector<int>& C_max, int lb) {
         const int v = (*order)[i];
 
         int mc_prev, mc_cur;
-        #pragma omp atomic read acquire
-        mc_prev = mc_cur = mc;
+        {
+            #pragma omp critical
+            mc_prev = mc_cur = mc;
+        }
 
         if ((*K)[v] > mc_cur) {
             for (long long j = (*V)[v]; j < (*V)[v + 1]; j++)
@@ -180,16 +180,12 @@ int pmc_heu::search_cores(const pmc_graph& G, std::vector<int>& C_max, int lb) {
                 branch(P, 1 , mc_cur, C, ind);
 
                 if (mc_cur > mc_prev) {
-                    #pragma omp atomic read acquire
-                    mc_prev = mc;
+                    C.push_back(v);
 
-                    if (mc_cur > mc_prev) {
-                        #pragma omp atomic write release
+                    #pragma omp critical
+                    if (mc_cur > mc) {
                         mc = mc_cur;
 
-                        C.push_back(v);
-
-                        #pragma omp critical
                         std::swap(C_max, C);
                         print_info(C_max);
                     }

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -20,7 +20,6 @@
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_maxclique.h"
 
-#include <cstdint>
 #include <cstring>
 
 using namespace std;
@@ -31,7 +30,7 @@ int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -70,7 +69,7 @@ int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
                 }
                 P = T;
             }
-            pruned[u] = 1;
+            pruned[u] = true;
         }
     }
 
@@ -88,7 +87,7 @@ void pmc_maxclique::branch(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        const std::vector<std::uint8_t>& pruned,
+        const bool_vector& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -157,7 +156,7 @@ int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -196,7 +195,7 @@ int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
                 }
                 P = T;
             }
-            pruned[u] = 1;
+            pruned[u] = true;
             for (long long j = (*vertices)[u]; j < (*vertices)[u + 1]; j++) {
                 adj[u][(*edges)[j]] = false;
                 adj[(*edges)[j]][u] = false;
@@ -217,9 +216,9 @@ void pmc_maxclique::branch_dense(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        std::vector<std::uint8_t>& pruned,
+        bool_vector& pruned,
         int& mc,
-        vector<vector<std::uint8_t>> &adj) {
+        std::vector<bool_vector>& adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -31,7 +31,7 @@ int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -88,7 +88,7 @@ void pmc_maxclique::branch(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        std::vector<int>& pruned,
+        const std::vector<std::uint8_t>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -157,7 +157,7 @@ int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -217,7 +217,7 @@ void pmc_maxclique::branch_dense(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        std::vector<int>& pruned,
+        std::vector<std::uint8_t>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -20,6 +20,8 @@
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_maxclique.h"
 
+#include <cstring>
+
 using namespace std;
 using namespace pmc;
 

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -31,8 +31,7 @@ int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -75,8 +74,6 @@ int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
         }
     }
 
-    if (pruned) delete[] pruned;
-
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
     G.print_break();
@@ -91,7 +88,7 @@ void pmc_maxclique::branch(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -160,8 +157,7 @@ int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -207,7 +203,6 @@ int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
             }
         }
     }
-    if (pruned) delete[] pruned;
 
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
@@ -222,7 +217,7 @@ void pmc_maxclique::branch_dense(
         vector<short>& ind,
         vector<int>& C,
         vector<int>& C_max,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -20,6 +20,7 @@
 #include "pmc/pmc_debug_utils.h"
 #include "pmc/pmc_maxclique.h"
 
+#include <cstdint>
 #include <cstring>
 
 using namespace std;
@@ -223,7 +224,7 @@ void pmc_maxclique::branch_dense(
         vector<int>& C_max,
         int* &pruned,
         int& mc,
-        vector<vector<bool>> &adj) {
+        vector<vector<std::uint8_t>> &adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmc_maxclique.cpp
+++ b/pmc_maxclique.cpp
@@ -27,8 +27,8 @@ using namespace pmc;
 
 int pmc_maxclique::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
+    vertices = &G.get_vertices();
+    edges = &G.get_edges();
     degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
@@ -151,8 +151,8 @@ void pmc_maxclique::branch(
 
 int pmc_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
+    vertices = &G.get_vertices();
+    edges = &G.get_edges();
     degree = G.get_degree();
     auto adj = G.adj;
 

--- a/pmc_utils.cpp
+++ b/pmc_utils.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "pmc/pmc_utils.h"
+#include "pmc/pmc_debug_utils.h"
 
 #include <cassert>
 #include <cstring>
@@ -76,7 +77,7 @@ string memory_usage() {
     return mem.str();
 }
 
-void indent(int level, string str) {
+void indent(int level) {
     for (int i = 0; i < level; i++)
         cout << "   ";
     cout << "(" << level << ") ";
@@ -88,6 +89,8 @@ void print_max_clique(vector<int>& C) {
     for(int i = 0; i < C.size(); i++)
         cout << C[i] + 1 << " ";
     cout << endl;
+#else
+    discard(C);
 #endif
 }
 
@@ -106,6 +109,8 @@ void print_n_maxcliques(set< vector<int> > C, int n) {
         }
         else break;
     }
+#else
+    discard(C, n);
 #endif
 }
 

--- a/pmc_utils.cpp
+++ b/pmc_utils.cpp
@@ -20,6 +20,7 @@
 #include "pmc/pmc_utils.h"
 
 #include <cassert>
+#include <cstring>
 #include <dirent.h>
 #include <fstream>
 #include <iostream>

--- a/pmc_utils.cpp
+++ b/pmc_utils.cpp
@@ -19,6 +19,13 @@
 
 #include "pmc/pmc_utils.h"
 
+#include <cassert>
+#include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <sys/time.h>
+
 using namespace std;
 
 bool fexists(const char *filename) {

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -31,7 +31,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
 //    degree = G.get_degree();
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -92,7 +92,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
                     }
                     P = T;
                 }
-                pruned[u] = 1;
+                pruned[u] = true;
 
                 // dynamically reduce graph in a thread-safe manner
                 if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
@@ -118,7 +118,7 @@ void pmcx_maxclique::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<std::uint8_t>& pruned,
+        bool_vector& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -183,7 +183,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 //    degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -246,7 +246,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
                     }
                     P = T;
                 }
-                pruned[u] = 1;
+                pruned[u] = true;
                 for (long long j = vs[u]; j < vs[u + 1]; j++) {
                     adj[u][es[j]] = false;
                     adj[es[j]][u] = false;
@@ -277,9 +277,9 @@ void pmcx_maxclique::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<std::uint8_t>& pruned,
+        bool_vector& pruned,
         int& mc,
-        vector<vector<std::uint8_t>> &adj) {
+        std::vector<bool_vector>& adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -28,9 +28,6 @@ using namespace pmc;
 
 int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
-//    degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
@@ -178,9 +175,6 @@ void pmcx_maxclique::branch(
  */
 int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
-//    degree = G.get_degree();
     auto adj = G.adj;
 
     bool_vector pruned(G.num_vertices());

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -284,7 +284,7 @@ void pmcx_maxclique::branch_dense(
         vector< vector<int> >& colors,
         int* &pruned,
         int& mc,
-        vector<vector<bool>> &adj) {
+        vector<vector<std::uint8_t>> &adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -18,6 +18,10 @@
  */
 
 #include "pmc/pmcx_maxclique.h"
+#include "pmc/pmc_neigh_coloring.h"
+#include "pmc/pmc_neigh_cores.h"
+
+#include <cstring>
 
 using namespace std;
 using namespace pmc;

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -31,7 +31,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
 //    degree = G.get_degree();
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -84,7 +84,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
                     if (P.size() > mc) {
                         neigh_cores_bound(vs,es,P,ind,mc);
                         if (P.size() > mc && P[0].get_bound() >= mc) {
-                            neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,pruned,mc);
+                            neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,mc);
                             if (P.back().get_bound() > mc) {
                                 branch(vs,es,P, ind, C, C_max, colors, pruned, mc);
                             }
@@ -118,7 +118,7 @@ void pmcx_maxclique::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<int>& pruned,
+        std::vector<std::uint8_t>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -143,7 +143,7 @@ void pmcx_maxclique::branch(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1)
-                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, pruned, mc);
+                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, mc);
                     branch(vs, es, R, ind, C, C_max, colors, pruned, mc);
                 }
                 else if (C.size() > mc) {
@@ -183,7 +183,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 //    degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -277,7 +277,7 @@ void pmcx_maxclique::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<int>& pruned,
+        std::vector<std::uint8_t>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -31,8 +31,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
 //    degree = G.get_degree();
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -104,7 +103,6 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
             }
         }
     }
-    if (pruned) delete[] pruned;
 
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
@@ -120,7 +118,7 @@ void pmcx_maxclique::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -185,8 +183,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 //    degree = G.get_degree();
     auto adj = G.adj;
 
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -265,8 +262,6 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
         }
     }
 
-    if (pruned) delete[] pruned;
-
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
     G.print_break();
@@ -282,7 +277,7 @@ void pmcx_maxclique::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmcx_maxclique.cpp
+++ b/pmcx_maxclique.cpp
@@ -84,7 +84,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
                     if (P.size() > mc) {
                         neigh_cores_bound(vs,es,P,ind,mc);
                         if (P.size() > mc && P[0].get_bound() >= mc) {
-                            neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,mc);
+                            neigh_coloring_bound(vs,es,P,ind,C,colors,mc);
                             if (P.back().get_bound() > mc) {
                                 branch(vs,es,P, ind, C, C_max, colors, pruned, mc);
                             }
@@ -96,7 +96,7 @@ int pmcx_maxclique::search(pmc_graph& G, vector<int>& sol) {
 
                 // dynamically reduce graph in a thread-safe manner
                 if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
-                    G.reduce_graph( vs, es, pruned, G, i+lb_idx, mc);
+                    G.reduce_graph( vs, es, pruned, G);
                     G.graph_stats(G, mc, i+lb_idx, sec);
                     induce_time[omp_get_thread_num()] = get_time();
                 }
@@ -118,7 +118,7 @@ void pmcx_maxclique::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        bool_vector& pruned,
+        const bool_vector& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -143,7 +143,7 @@ void pmcx_maxclique::branch(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1)
-                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, mc);
+                    neigh_coloring_bound(vs, es, R, ind, C, colors, mc);
                     branch(vs, es, R, ind, C, C_max, colors, pruned, mc);
                 }
                 else if (C.size() > mc) {
@@ -238,7 +238,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
                         // neighborhood core ordering and pruning
                         neigh_cores_bound(vs,es,P,ind,mc);
                         if (P.size() > mc && P[0].get_bound() >= mc) {
-                            neigh_coloring_dense(vs,es,P,ind,C,C_max,colors,mc, adj);
+                            neigh_coloring_dense(P,C,colors,mc, adj);
                             if (P.back().get_bound() > mc) {
                                 branch_dense(vs,es,P, ind, C, C_max, colors, pruned, mc, adj);
                             }
@@ -254,7 +254,7 @@ int pmcx_maxclique::search_dense(pmc_graph& G, vector<int>& sol) {
 
                 // dynamically reduce graph in a thread-safe manner
                 if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
-                    G.reduce_graph( vs, es, pruned, G, i+lb_idx, mc);
+                    G.reduce_graph( vs, es, pruned, G);
                     G.graph_stats(G, mc, i+lb_idx, sec);
                     induce_time[omp_get_thread_num()] = get_time();
                 }
@@ -277,9 +277,9 @@ void pmcx_maxclique::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        bool_vector& pruned,
+        const bool_vector& pruned,
         int& mc,
-        std::vector<bool_vector>& adj) {
+        const std::vector<bool_vector>& adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {
@@ -298,7 +298,7 @@ void pmcx_maxclique::branch_dense(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1)
-                    neigh_coloring_dense(vs, es, R, ind, C, C_max, colors, mc, adj);
+                    neigh_coloring_dense(R, C, colors, mc, adj);
                     branch_dense(vs, es, R, ind, C, C_max, colors, pruned, mc, adj);
                 }
                 else if (C.size() > mc) {

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -76,7 +76,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
                             P.push_back(Vertex(es[j], (*degree)[es[j]]));
 
                 if (P.size() > mc) {
-                    neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,mc);
+                    neigh_coloring_bound(vs,es,P,ind,C,colors,mc);
                     if (P.back().get_bound() > mc) {
                         branch(vs,es,P, ind, C, C_max, colors, pruned, mc);
                     }
@@ -87,7 +87,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
 
             // dynamically reduce graph in a thread-safe manner
             if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
-                G.reduce_graph( vs, es, pruned, G, i+lb_idx, mc);
+                G.reduce_graph( vs, es, pruned, G);
                 G.graph_stats(G, mc, i+lb_idx, sec);
                 induce_time[omp_get_thread_num()] = get_time();
             }
@@ -136,7 +136,7 @@ void pmcx_maxclique_basic::branch(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1) bound check
-                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, mc);
+                    neigh_coloring_bound(vs, es, R, ind, C, colors, mc);
                     // search reordered R
                     branch(vs, es, R, ind, C, C_max, colors, pruned, mc);
                 }
@@ -208,7 +208,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
     vector<Vertex> V;
     V.reserve(G.num_vertices());
     G.order_vertices(V,G,lb_idx,lb,vertex_ordering,decr_order);
-    DEBUG_PRINTF("|V| = %i\n", V.size());
+    DEBUG_PRINTF("|V| = %u\n", V.size());
 
     vector<short> ind(G.num_vertices(),0);
     vector<int> es = G.get_edges_array();
@@ -232,7 +232,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
                             P.push_back(Vertex(es[j], (*degree)[es[j]]));
 
                 if (P.size() > mc) {
-                    neigh_coloring_dense(vs,es,P,ind,C,C_max,colors,mc, adj);
+                    neigh_coloring_dense(P,C,colors,mc, adj);
                     if (P.back().get_bound() > mc) {
                         branch_dense(vs,es,P, ind, C, C_max, colors, pruned, mc, adj);
                     }
@@ -247,7 +247,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
 
             // dynamically reduce graph in a thread-safe manner
             if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
-                G.reduce_graph( vs, es, pruned, G, i+lb_idx, mc);
+                G.reduce_graph( vs, es, pruned, G);
                 G.graph_stats(G, mc, i+lb_idx, sec);
                 induce_time[omp_get_thread_num()] = get_time();
             }
@@ -291,7 +291,7 @@ void pmcx_maxclique_basic::branch_dense(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1)
-                    neigh_coloring_dense(vs, es, R, ind, C, C_max, colors, mc, adj);
+                    neigh_coloring_dense(R, C, colors, mc, adj);
                     branch_dense(vs, es, R, ind, C, C_max, colors, pruned, mc, adj);
                 }
                 else if (C.size() > mc) {

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -30,7 +30,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -76,7 +76,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
                             P.push_back(Vertex(es[j], (*degree)[es[j]]));
 
                 if (P.size() > mc) {
-                    neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,pruned,mc);
+                    neigh_coloring_bound(vs,es,P,ind,C,C_max,colors,mc);
                     if (P.back().get_bound() > mc) {
                         branch(vs,es,P, ind, C, C_max, colors, pruned, mc);
                     }
@@ -111,7 +111,7 @@ void pmcx_maxclique_basic::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<int>& pruned,
+        const std::vector<std::uint8_t>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -136,7 +136,7 @@ void pmcx_maxclique_basic::branch(
 
                 if (R.size() > 0) {
                     // color graph induced by R and sort for O(1) bound check
-                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, pruned, mc);
+                    neigh_coloring_bound(vs, es, R, ind, C, C_max, colors, mc);
                     // search reordered R
                     branch(vs, es, R, ind, C, C_max, colors, pruned, mc);
                 }
@@ -184,7 +184,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<int> pruned(G.num_vertices(), 0);
+    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
 
     int mc = lb, i = 0, u = 0;
 
@@ -271,7 +271,7 @@ void pmcx_maxclique_basic::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<int>& pruned,
+        std::vector<std::uint8_t>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -27,8 +27,6 @@ using namespace pmc;
 
 int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
     degree = G.get_degree();
     bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
@@ -179,8 +177,6 @@ void pmcx_maxclique_basic::branch(
 
 int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
 
-    vertices = G.get_vertices();
-    edges = G.get_edges();
     degree = G.get_degree();
     auto adj = G.adj;
 

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -30,8 +30,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -95,8 +94,6 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
         }
     }
 
-    if (pruned) delete[] pruned;
-
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
     G.print_break();
@@ -114,7 +111,7 @@ void pmcx_maxclique_basic::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -187,8 +184,8 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    int* pruned = new int[G.num_vertices()];
-    memset(pruned, 0, G.num_vertices() * sizeof(int));
+    std::vector<int> pruned(G.num_vertices(), 0);
+
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -257,8 +254,6 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
         }
     }
 
-    if (pruned) delete[] pruned;
-
     sol.resize(mc);
     for (int i = 0; i < C_max.size(); i++)  sol[i] = C_max[i];
     G.print_break();
@@ -276,7 +271,7 @@ void pmcx_maxclique_basic::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        int* &pruned,
+        std::vector<int>& pruned,
         int& mc,
         vector<vector<std::uint8_t>> &adj) {
 

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -30,7 +30,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
     vertices = G.get_vertices();
     edges = G.get_edges();
     degree = G.get_degree();
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
     int mc = lb, i = 0, u = 0;
 
     // initial pruning
@@ -83,7 +83,7 @@ int pmcx_maxclique_basic::search(pmc_graph& G, vector<int>& sol) {
                 }
                 P = T;
             }
-            pruned[u] = 1;
+            pruned[u] = true;
 
             // dynamically reduce graph in a thread-safe manner
             if ((get_time() - induce_time[omp_get_thread_num()]) > wait_time) {
@@ -111,7 +111,7 @@ void pmcx_maxclique_basic::branch(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        const std::vector<std::uint8_t>& pruned,
+        const bool_vector& pruned,
         int& mc) {
 
     // stop early if ub is reached
@@ -184,7 +184,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
     degree = G.get_degree();
     auto adj = G.adj;
 
-    std::vector<std::uint8_t> pruned(G.num_vertices(), 0);
+    bool_vector pruned(G.num_vertices());
 
     int mc = lb, i = 0, u = 0;
 
@@ -239,7 +239,7 @@ int pmcx_maxclique_basic::search_dense(pmc_graph& G, vector<int>& sol) {
                 }
                 P = T;
             }
-            pruned[u] = 1;
+            pruned[u] = true;
             for (long long j = vs[u]; j < vs[u + 1]; j++) {
                 adj[u][es[j]] = false;
                 adj[es[j]][u] = false;
@@ -271,9 +271,9 @@ void pmcx_maxclique_basic::branch_dense(
         vector<int>& C,
         vector<int>& C_max,
         vector< vector<int> >& colors,
-        std::vector<std::uint8_t>& pruned,
+        bool_vector& pruned,
         int& mc,
-        vector<vector<std::uint8_t>> &adj) {
+        std::vector<bool_vector>& adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -278,7 +278,7 @@ void pmcx_maxclique_basic::branch_dense(
         vector< vector<int> >& colors,
         int* &pruned,
         int& mc,
-        vector<vector<bool>> &adj) {
+        vector<vector<std::uint8_t>> &adj) {
 
     // stop early if ub is reached
     if (not_reached_ub) {

--- a/pmcx_maxclique_basic.cpp
+++ b/pmcx_maxclique_basic.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "pmc/pmcx_maxclique_basic.h"
+#include "pmc/pmc_neigh_coloring.h"
+
+#include <cstring>
 
 using namespace std;
 using namespace pmc;


### PR DESCRIPTION
This PR includes the following changes:
- https://github.com/young-seoulrobotics/pmc/pull/1
- https://github.com/young-seoulrobotics/pmc/pull/2
- https://github.com/young-seoulrobotics/pmc/pull/3

## [Conform the library to better coding standards](https://github.com/young-seoulrobotics/pmc/pull/1)

- No `using namespace std;` in any headers ([SO](https://stackoverflow.com/questions/5849457/using-namespace-in-c-headers))
- Replaced `std::vector<bool>` and `std::vector<int>` with `pmc::bool_vector`
    - ~~Replace `std::vector<bool>` with `std::vector<std::uint8_t>` to avoid race conditions in parallel for~~
    - ~~Replace `int*` with `std::vector<int>`~~
- Cleaned includes
- Corrected a bit of constness
- Added some compiler options such as `-Wall -Werror` to tidy up the code
    - Removed all the unused parameters

## [Fix intermittent data races](https://github.com/young-seoulrobotics/pmc/pull/2)

- Fixed data races when accessing `mc` and `found_ub` in `pmc_heu::search_bounds()`
- Minimized the critical section by swapping the containers

## [Correct synchronization in `pmc_heu::search_bounds`](https://github.com/young-seoulrobotics/pmc/pull/3)

- Made sure that both `mc` and `C_max` are updated consistently